### PR TITLE
Genericise neos output to game output

### DIFF
--- a/content/manifestGame.njk
+++ b/content/manifestGame.njk
@@ -1,0 +1,5 @@
+---
+permalink: /api/manifest.game
+---
+{% for episode in episodes %}
+{{episode | toGameOutput}}{% endfor %}

--- a/content/manifestNeos.njk
+++ b/content/manifestNeos.njk
@@ -1,5 +1,0 @@
----
-permalink: /api/manifest.neos
----
-{% for episode in episodes %}
-{{episode | toNeosOutput}}{% endfor %}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -9,7 +9,7 @@ module.exports = function(eleventyConfig) {
 
 	// eleventyConfig.setServerPassthroughCopyBehavior("passthrough");
 
-	eleventyConfig.addFilter("toNeosOutput", function(value) {
+	eleventyConfig.addFilter("toGameOutput", function(value) {
 		return `${value.title}|${value.audio}|${value.srt}`;
 	});
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -10,7 +10,10 @@ module.exports = function(eleventyConfig) {
 	// eleventyConfig.setServerPassthroughCopyBehavior("passthrough");
 
 	eleventyConfig.addFilter("toGameOutput", function(value) {
-		return `${value.title}|${value.audio}|${value.srt}`;
+		if (value.tags.contains('old')){
+			value.title = `${value.title} - OLD`;
+		}
+		return `${value.title}|https://officehours.probableprime.co.uk${value.audio}|https://officehours.probableprime.co.uk${value.srt}`;
 	});
 
 


### PR DESCRIPTION
Seeing as multiple games can accept this input (Neos, Resonite, Overte etc.), I believe genericising the ouput to just be for "games" is more appropriate.

I have also now edited the ouput to also differentiate in-game between episodes on older platforms. As well as making the URL absolute to make it easier to parse in games.